### PR TITLE
Version bump to v0.1.8

### DIFF
--- a/lib/delayed_after_commit/version.rb
+++ b/lib/delayed_after_commit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DelayedAfterCommit
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
It appears we already have a v0.1.7 tag
so this commit is to make sure we move to a clean version.

<img width="361" alt="Screenshot 2024-10-30 at 18 42 10" src="https://github.com/user-attachments/assets/a5017f24-f1be-48be-8251-f82b21a93f70">
