### PR TITLE
[LEA-5114] Fixing the issue with using incorrect queue

### DIFF
--- a/lib/delayed_after_commit.rb
+++ b/lib/delayed_after_commit.rb
@@ -31,7 +31,7 @@ module DelayedAfterCommit
       method = args.first
       delayed_method_name = "delayed_after_#{opts[:on]}_#{method}"
       define_method(delayed_method_name) do |m = method|
-        Worker.perform_async(self.class.name, m.to_s, id.to_s, retry_max.to_i, 0, queue.to_s)
+        Worker.set(queue:).perform_async(self.class.name, m.to_s, id.to_s, retry_max.to_i, 0, queue.to_s)
       end
       after_commit(delayed_method_name.to_sym, opts, &block)
     end

--- a/lib/delayed_after_commit/version.rb
+++ b/lib/delayed_after_commit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DelayedAfterCommit
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end

--- a/lib/delayed_after_commit/worker.rb
+++ b/lib/delayed_after_commit/worker.rb
@@ -14,7 +14,7 @@ module DelayedAfterCommit
         obj.send(method) if obj.present?
       rescue StandardError => e
         if retry_max.present? && retry_count < retry_max
-          self.class.perform_in(retry_count.minutes, class_name, method, id, retry_max, retry_count + 1, queue.to_s)
+          self.class.set(queue:).perform_in(retry_count.minutes, class_name, method, id, retry_max, retry_count + 1, queue.to_s)
         end
         raise e
       end

--- a/spec/lib/delayed_after_commit_spec.rb
+++ b/spec/lib/delayed_after_commit_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe 'delayed after commit callback' do
       Sidekiq::Testing.fake! do
         expect do
           User.create!(name: 'Alice')
-        end.to change(Sidekiq::Queues['default'], :size).by(1)
-        expect(Sidekiq::Queues['default'].last["args"]).to include("calculate_number_of_letters_in_name")
+        end.to change(Sidekiq::Queues['high'], :size).by(1)
+        expect(Sidekiq::Queues['high'].last["args"]).to include("calculate_number_of_letters_in_name")
       end
     end
   end
@@ -67,7 +67,7 @@ RSpec.describe 'delayed after commit callback' do
 
         job = Sidekiq::Queues["default"].last
         expect(job["retry"]).to be(false) # We are not using sidekiq's retry feature
-        expect(job["args"]).to eq(["User", "failing_callback", bob.id.to_s, 3])
+        expect(job["args"]).to eq(["User", "failing_callback", bob.id.to_s, 3, 0, "default"])
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ class User < ActiveRecord::Base
   attr_accessor :increment_enabled, :fail_enabled
 
   delayed_after_update :increment_number_of_updates, if: :increment_enabled
-  delayed_after_create :calculate_number_of_letters_in_name
+  delayed_after_create :calculate_number_of_letters_in_name, queue: 'high'
 
   delayed_after_update :failing_callback, if: :fail_enabled, retry_max: 3
 


### PR DESCRIPTION
Issue:
https://intellum.atlassian.net/browse/LEA-5114

This issue was identified because `default` queue were flooded and slowed, and there were high priority jobs which got enqueued on `default` queue. After investigation we found that the issue is with this gem because its not respecting the queue name passed in parameter.
This PR tries to fix this issue by correctly setting the queue name using `set(queue:)` method.